### PR TITLE
Fix calendar background color

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -161,11 +161,6 @@
     filter: invert(100%) hue-rotate(180deg) brightness(1.1) contrast(105%)!important;
   }
 
-/* Background color of day selection from the pop-up panel (the white frame is cause by *:before,img,svg)*/
-  .HkPXyb{
-    background-color: #f9f9f9;
-  }
-
 /* Menu uninvertion of uploading attachment from Google Drive (the id's are not static and this function doesn't always work) */
   #vqd3vxfo4jpl,
 #pnsketfj08m


### PR DESCRIPTION
Fixes https://github.com/pyxelr/Dark_Google_Calendar/issues/4.

Removes a custom background-color property for the calendar background.

With the custom `background-color`:
![image](https://user-images.githubusercontent.com/820984/78926893-c046e500-7a52-11ea-9367-6610d21bff84.png)

Without the custom `background-color` (the change included in this PR):
![image](https://user-images.githubusercontent.com/820984/78926744-765dff00-7a52-11ea-8cfe-a03f30cd75fc.png)
