### PR TITLE
Use raw GitHub URL for @updateURL

### DIFF
--- a/Style.user.css
+++ b/Style.user.css
@@ -3,7 +3,7 @@
 @namespace      pyxelr
 @version        2.60.8
 @homepageURL https://github.com/pyxelr/Dark_Google_Calendar
-@updateURL   https://github.com/pyxelr/Dark_Google_Calendar/blob/master/Style.user.css
+@updateURL   https://raw.githubusercontent.com/pyxelr/Dark_Google_Calendar/master/Style.user.css
 @license     MIT
 @author         pyxelr
 ==/UserStyle== */


### PR DESCRIPTION
Fixes https://github.com/pyxelr/Dark_Google_Calendar/issues/6.

Uses GitHub's raw URL for `@updateURL` in `Style.user.css`.  This allows the Stylus add-on to perform updates correctly.