### PR TITLE
add additional class for hover guest images

### DIFF
--- a/Google-DarkCalendar.user.css
+++ b/Google-DarkCalendar.user.css
@@ -420,7 +420,7 @@
 
     /* ==== GENERAL ==== */
     /* Inversion of the avatar displayed in the frame after hovering over the image in the "Add guests" menu while creating a new event */
-    .jgZKbb {
+    .jgZKbb, .oMU93c {
         filter: invert(100%) hue-rotate(180deg) brightness(1.1) !important;
     }
 }


### PR DESCRIPTION
I don't know if this happened because it's GSuite or if the class name has changed.

Before:
![before](https://user-images.githubusercontent.com/1125067/109349325-ac27f400-786d-11eb-8c13-ffe328aa5d5c.png)


After:
![after](https://user-images.githubusercontent.com/1125067/109349311-a7fbd680-786d-11eb-8c86-e25a283a65ef.png)
