### PR TITLE
make back arrow in settings visible

### DIFF
--- a/Google-DarkCalendar.user.css
+++ b/Google-DarkCalendar.user.css
@@ -143,7 +143,6 @@
     /* Change of arrow color in the settings menu*/
     .gb_yc svg,
     .gb_kc svg {
-        color: black!important;
         opacity: .54!important;
     }
 

--- a/Style.css
+++ b/Style.css
@@ -143,7 +143,6 @@
     /* Change of arrow color in the settings menu*/
     .gb_yc svg,
     .gb_kc svg {
-        color: black!important;
         opacity: .54!important;
     }
 


### PR DESCRIPTION
I noticed you ported my previous change back into the Style.css file, so I changed both files this time. I don't see a build process, so I hope that's helpful. Also thanks for responding so quickly! :+1: 

Before:
![settings-before](https://user-images.githubusercontent.com/1125067/109998505-31e1ee80-7d09-11eb-813e-af361e126a66.gif)

After:
![settings-after](https://user-images.githubusercontent.com/1125067/109998515-35757580-7d09-11eb-881e-147aea94475f.gif)

Original:
![settings-original](https://user-images.githubusercontent.com/1125067/109998536-3ad2c000-7d09-11eb-9456-3db72d93332f.gif)
