### PR TITLE
Invert Google Maps right panel photos

### DIFF
--- a/Google-DarkCalendar.user.css
+++ b/Google-DarkCalendar.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name        Dark Google Calendar
 @namespace   pyxelr
-@version     2.7.21
+@version     2.7.22
 @homepageURL https://github.com/pyxelr/dark-google-calendar
 @supportURL  https://github.com/pyxelr/dark-google-calendar/issues
 @updateURL   https://github.com/pyxelr/dark-google-calendar/raw/master/Google-DarkCalendar.user.css
@@ -487,6 +487,14 @@
 @-moz-document domain("google.com") {
     /* Inversion of Google Map */
     #map.map {
+        filter: invert(100%) hue-rotate(180deg) brightness(1.1) contrast(105%)!important;
+    }
+}
+
+@-moz-document url-prefix("https://www.google.com/maps/companion?") {
+    /* Inversion of Google Maps photos in right hand panel */
+    .jtJMuf,
+    .ahyv7c {
         filter: invert(100%) hue-rotate(180deg) brightness(1.1) contrast(105%)!important;
     }
 }


### PR DESCRIPTION
Before A:
![image](https://github.com/pyxelr/dark-google-calendar/assets/133218/29f41c19-f1e1-47e9-9ce7-e647056d3d00)

After A:
![image](https://github.com/pyxelr/dark-google-calendar/assets/133218/ed5b668a-6236-4045-96f4-64fb4c054c35)

Before B:
![image](https://github.com/pyxelr/dark-google-calendar/assets/133218/e44dc566-4373-4776-9ae1-94a0e762f9d3)

After B:
![image](https://github.com/pyxelr/dark-google-calendar/assets/133218/255c3ff3-0efe-42b8-92c4-a4ba74f9844a)
