### PR TITLE
Add more specific selector to past events

### DIFF
--- a/Google-DarkCalendar.user.css
+++ b/Google-DarkCalendar.user.css
@@ -311,7 +311,8 @@
     }
 
     /* Font of past events */
-    .KF4T6b.smECzc.UflSff.jKgTF.QGRmIf {
+    .KF4T6b.smECzc.UflSff.jKgTF.QGRmIf,
+    .KF4T6b.UflSff .nHqeVd {
         color: var(--font-color-past-events-with-time) !important;
     }
     

--- a/Google-DarkCalendar.user.css
+++ b/Google-DarkCalendar.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name        Dark Google Calendar
 @namespace   pyxelr
-@version     2.7.23
+@version     2.7.24
 @homepageURL https://github.com/pyxelr/dark-google-calendar
 @supportURL  https://github.com/pyxelr/dark-google-calendar/issues
 @updateURL   https://github.com/pyxelr/dark-google-calendar/raw/master/Google-DarkCalendar.user.css


### PR DESCRIPTION
It seems Google has updated the selectors for the past events so the --font-color-past-events-with-time color is not applied correctly.

I guess this fixes #25.

Before:
![Screenshot_49](https://github.com/pyxelr/dark-google-calendar/assets/7290072/c60ca319-c273-4b30-b5ea-205007e048d0)
![Screenshot_44](https://github.com/pyxelr/dark-google-calendar/assets/7290072/aaec0564-0b1f-44b3-92c1-bda87117d5dd)
![Screenshot_45](https://github.com/pyxelr/dark-google-calendar/assets/7290072/20be4dee-eae6-4856-a29f-0d149ff44d0b)

After:
![Screenshot_43](https://github.com/pyxelr/dark-google-calendar/assets/7290072/b7db12a4-e93b-48d8-8c3b-7fc900dc8c98)
![Screenshot_46](https://github.com/pyxelr/dark-google-calendar/assets/7290072/59f9ebba-1cf0-463c-950c-438dd87b1d8b)
![Screenshot_47](https://github.com/pyxelr/dark-google-calendar/assets/7290072/f2911cef-acd5-492f-a4ad-a7ffd5eef24d)
